### PR TITLE
Add fee payer on init instructions for CPI with user as PDA

### DIFF
--- a/programs/klend/src/handlers/handler_init_obligation.rs
+++ b/programs/klend/src/handlers/handler_init_obligation.rs
@@ -57,9 +57,7 @@ pub struct InitObligation<'info> {
 
     pub lending_market: AccountLoader<'info, LendingMarket>,
 
-    /// CHECK: checked
     pub seed1_account: AccountInfo<'info>,
-    /// CHECK: checked
     pub seed2_account: AccountInfo<'info>,
 
     #[account(

--- a/programs/klend/src/handlers/handler_init_obligation.rs
+++ b/programs/klend/src/handlers/handler_init_obligation.rs
@@ -44,17 +44,22 @@ pub struct InitObligation<'info> {
     #[account(mut)]
     pub obligation_owner: Signer<'info>,
 
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
+
     #[account(init,
         seeds = [&[args.tag], &[args.id], obligation_owner.key().as_ref(), lending_market.key().as_ref(), seed1_account.key().as_ref(), seed2_account.key().as_ref()],
         bump,
-        payer = obligation_owner,
+        payer = fee_payer,
         space = OBLIGATION_SIZE + 8,
     )]
     pub obligation: AccountLoader<'info, Obligation>,
 
     pub lending_market: AccountLoader<'info, LendingMarket>,
 
+    /// CHECK: checked
     pub seed1_account: AccountInfo<'info>,
+    /// CHECK: checked
     pub seed2_account: AccountInfo<'info>,
 
     #[account(

--- a/programs/klend/src/handlers/handler_init_obligation.rs
+++ b/programs/klend/src/handlers/handler_init_obligation.rs
@@ -41,7 +41,6 @@ pub fn process(ctx: Context<InitObligation>, args: InitObligationArgs) -> Result
 #[derive(Accounts)]
 #[instruction(args: InitObligationArgs)]
 pub struct InitObligation<'info> {
-    #[account(mut)]
     pub obligation_owner: Signer<'info>,
 
     #[account(mut)]

--- a/programs/klend/src/handlers/handler_init_user_metadata.rs
+++ b/programs/klend/src/handlers/handler_init_user_metadata.rs
@@ -26,7 +26,6 @@ pub fn process(
 
 #[derive(Accounts)]
 pub struct InitUserMetadata<'info> {
-    #[account(mut)]
     pub owner: Signer<'info>,
 
     #[account(mut)]

--- a/programs/klend/src/handlers/handler_init_user_metadata.rs
+++ b/programs/klend/src/handlers/handler_init_user_metadata.rs
@@ -29,10 +29,13 @@ pub struct InitUserMetadata<'info> {
     #[account(mut)]
     pub owner: Signer<'info>,
 
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
+
     #[account(init,
         seeds = [BASE_SEED_USER_METADATA, owner.key().as_ref()],
         bump,
-        payer = owner,
+        payer = fee_payer,
         space = USER_METADATA_SIZE + 8,
     )]
     pub user_metadata: AccountLoader<'info, UserMetadata>,


### PR DESCRIPTION
The account that pays for rent can't have data, so it can't be a PDA:

```
'Program FL3X2pRsQ9zHENpZSKDRREtccwJuei8yg9fwDu9UN69Q invoke [1]',
    'Program log: Instruction: InitKaminoUserAccount',
    'Program KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD invoke [2]',
    'Program log: Instruction: InitUserMetadata',
    'Program 11111111111111111111111111111111 invoke [3]',
    'Transfer: `from` must not carry data',
    'Program 11111111111111111111111111111111 failed: invalid program argument',
...
 ```

This PR adds a `fee_payer` account to `handler_init_user_metadata` and `handler_init_obligation` so we can use a PDA as owner and pass other signer to pay for rent.