### PR TITLE
Release 1.8.1

### DIFF
--- a/programs/klend/src/handlers/handler_borrow_obligation_liquidity.rs
+++ b/programs/klend/src/handlers/handler_borrow_obligation_liquidity.rs
@@ -45,6 +45,7 @@ pub fn process<'info>(
                     let referrer_token_state = referrer_token_state_loader.load_mut()?;
 
                     validate_referrer_token_state(
+                        &crate::ID,
                         &referrer_token_state,
                         referrer_token_state_loader.key(),
                         borrow_reserve.liquidity.mint_pubkey,

--- a/programs/klend/src/handlers/handler_flash_repay_reserve_liquidity.rs
+++ b/programs/klend/src/handlers/handler_flash_repay_reserve_liquidity.rs
@@ -34,6 +34,7 @@ pub fn process(
                 let referrer_token_state = &mut referrer_token_state_loader.load_mut()?;
 
                 validate_referrer_token_state(
+                    &crate::ID,
                     referrer_token_state,
                     referrer_token_state_loader.key(),
                     reserve.liquidity.mint_pubkey,

--- a/programs/klend/src/handlers/handler_init_referrer_token_state.rs
+++ b/programs/klend/src/handlers/handler_init_referrer_token_state.rs
@@ -5,9 +5,10 @@ use crate::{
     LendingMarket, ReferrerTokenState, Reserve,
 };
 
-pub fn process(ctx: Context<InitReferrerTokenState>, referrer: Pubkey) -> Result<()> {
+pub fn process(ctx: Context<InitReferrerTokenState>) -> Result<()> {
     let mut referrer_token_state = ctx.accounts.referrer_token_state.load_init()?;
     let reserve = ctx.accounts.reserve.load()?;
+    let referrer = ctx.accounts.referrer.key();
     let bump = ctx.bumps.referrer_token_state;
 
     *referrer_token_state = ReferrerTokenState {
@@ -23,7 +24,6 @@ pub fn process(ctx: Context<InitReferrerTokenState>, referrer: Pubkey) -> Result
 }
 
 #[derive(Accounts)]
-#[instruction(referrer: Pubkey)]
 pub struct InitReferrerTokenState<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
@@ -35,8 +35,10 @@ pub struct InitReferrerTokenState<'info> {
     )]
     pub reserve: AccountLoader<'info, Reserve>,
 
+    pub referrer: AccountInfo<'info>,
+
     #[account(init,
-        seeds = [BASE_SEED_REFERRER_TOKEN_STATE, referrer.as_ref(), reserve.key().as_ref()],
+        seeds = [BASE_SEED_REFERRER_TOKEN_STATE, referrer.key().as_ref(), reserve.key().as_ref()],
         bump,
         payer = payer,
         space = REFERRER_TOKEN_STATE_SIZE + 8,

--- a/programs/klend/src/handlers/handler_refresh_obligation.rs
+++ b/programs/klend/src/handlers/handler_refresh_obligation.rs
@@ -54,6 +54,7 @@ pub fn process(ctx: Context<RefreshObligation>) -> Result<()> {
             });
 
     lending_operations::refresh_obligation(
+        &crate::ID,
         obligation,
         lending_market,
         clock.slot,

--- a/programs/klend/src/handlers/handler_request_elevation_group.rs
+++ b/programs/klend/src/handlers/handler_request_elevation_group.rs
@@ -45,6 +45,7 @@ pub fn process(ctx: Context<RequestElevationGroup>, new_elevation_group: u8) -> 
             });
 
     lending_operations::request_elevation_group(
+        &crate::ID,
         obligation,
         &lending_market,
         slot,

--- a/programs/klend/src/handlers/handler_update_lending_market.rs
+++ b/programs/klend/src/handlers/handler_update_lending_market.rs
@@ -76,11 +76,8 @@ pub fn process(
             msg!("New value is {:?}", value);
             market.global_allowed_borrow_value = value;
         }
-        UpdateLendingMarketMode::UpdateGlobalUnhealthyBorrow => {
-            let value = u64::from_le_bytes(value[..8].try_into().unwrap());
-            msg!("Prv value is {:?}", market.global_unhealthy_borrow_value);
-            msg!("New value is {:?}", value);
-            market.global_unhealthy_borrow_value = value;
+        UpdateLendingMarketMode::DeprecatedUpdateGlobalUnhealthyBorrow => {
+            panic!("Deprecated field")
         }
         UpdateLendingMarketMode::UpdateMinFullLiquidationThreshold => {
             let value = u64::from_le_bytes(value[..8].try_into().unwrap());
@@ -221,17 +218,27 @@ pub fn process(
             );
             market.min_net_value_in_obligation_sf = min_net_value_in_obligation_sf;
         }
-        UpdateLendingMarketMode::UpdateMinValueSkipPriorityLiqCheck => {
-            let min_value_skip_liquidation_ltv_bf_checks =
+        UpdateLendingMarketMode::UpdateMinValueLtvSkipPriorityLiqCheck => {
+            let min_value_skip_liquidation_ltv_checks =
                 u64::from_le_bytes(value[..8].try_into().unwrap());
             msg!(
                 "Prev Value is {}",
-                market.min_value_skip_liquidation_ltv_bf_checks
+                market.min_value_skip_liquidation_ltv_checks
             );
-            msg!("New Value is {}", min_value_skip_liquidation_ltv_bf_checks);
+            msg!("New Value is {}", min_value_skip_liquidation_ltv_checks);
 
-            market.min_value_skip_liquidation_ltv_bf_checks =
-                min_value_skip_liquidation_ltv_bf_checks;
+            market.min_value_skip_liquidation_ltv_checks = min_value_skip_liquidation_ltv_checks;
+        }
+        UpdateLendingMarketMode::UpdateMinValueBfSkipPriorityLiqCheck => {
+            let min_value_skip_liquidation_bf_checks =
+                u64::from_le_bytes(value[..8].try_into().unwrap());
+            msg!(
+                "Prev Value is {}",
+                market.min_value_skip_liquidation_bf_checks
+            );
+            msg!("New Value is {}", min_value_skip_liquidation_bf_checks);
+
+            market.min_value_skip_liquidation_bf_checks = min_value_skip_liquidation_bf_checks;
         }
         UpdateLendingMarketMode::UpdatePaddingFields => {
             msg!("Prev Value is {:?}", market.reserved1);

--- a/programs/klend/src/lending_market/lending_checks.rs
+++ b/programs/klend/src/lending_market/lending_checks.rs
@@ -430,6 +430,7 @@ pub fn post_transfer_vault_balance_liquidity_reserve_checks(
 }
 
 pub fn validate_referrer_token_state(
+    program_id: &Pubkey,
     referrer_token_state: &ReferrerTokenState,
     referrer_token_state_key: Pubkey,
     mint: Pubkey,
@@ -453,7 +454,7 @@ pub fn validate_referrer_token_state(
             reserve_key.as_ref(),
             &[referrer_token_state.bump.try_into().unwrap()],
         ],
-        &crate::ID,
+        program_id,
     )
     .unwrap();
 

--- a/programs/klend/src/lib.rs
+++ b/programs/klend/src/lib.rs
@@ -230,11 +230,8 @@ pub mod kamino_lending {
         handler_request_elevation_group::process(ctx, elevation_group)
     }
 
-    pub fn init_referrer_token_state(
-        ctx: Context<InitReferrerTokenState>,
-        referrer: Pubkey,
-    ) -> Result<()> {
-        handler_init_referrer_token_state::process(ctx, referrer)
+    pub fn init_referrer_token_state(ctx: Context<InitReferrerTokenState>) -> Result<()> {
+        handler_init_referrer_token_state::process(ctx)
     }
 
     pub fn init_user_metadata(

--- a/programs/klend/src/state/lending_market.rs
+++ b/programs/klend/src/state/lending_market.rs
@@ -10,9 +10,8 @@ use super::{serde_bool_u8, serde_string, serde_utf_string};
 use crate::{
     utils::{
         CLOSE_TO_INSOLVENCY_RISKY_LTV, ELEVATION_GROUP_NONE, GLOBAL_ALLOWED_BORROW_VALUE,
-        GLOBAL_UNHEALTHY_BORROW_VALUE, LENDING_MARKET_SIZE, LIQUIDATION_CLOSE_FACTOR,
-        LIQUIDATION_CLOSE_VALUE, MAX_LIQUIDATABLE_VALUE_AT_ONCE, MIN_NET_VALUE_IN_OBLIGATION,
-        PROGRAM_VERSION,
+        LENDING_MARKET_SIZE, LIQUIDATION_CLOSE_FACTOR, LIQUIDATION_CLOSE_VALUE,
+        MAX_LIQUIDATABLE_VALUE_AT_ONCE, MIN_NET_VALUE_IN_OBLIGATION, PROGRAM_VERSION,
     },
     LendingError,
 };
@@ -53,7 +52,12 @@ pub struct LendingMarket {
     pub min_full_liquidation_value_threshold: u64,
 
     pub max_liquidatable_debt_market_value_at_once: u64,
-    pub global_unhealthy_borrow_value: u64,
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_deserializing, skip_serializing, default)
+    )]
+    #[derivative(Debug = "ignore")]
+    pub reserved0: [u8; 8],
     pub global_allowed_borrow_value: u64,
     #[cfg_attr(feature = "serde", serde(with = "serde_string", default))]
     pub risk_council: Pubkey,
@@ -81,22 +85,24 @@ pub struct LendingMarket {
     )]
     pub min_net_value_in_obligation_sf: u128,
 
-    pub min_value_skip_liquidation_ltv_bf_checks: u64,
+    pub min_value_skip_liquidation_ltv_checks: u64,
 
     #[cfg_attr(feature = "serde", serde(with = "serde_utf_string", default))]
     pub name: [u8; 32],
+
+    pub min_value_skip_liquidation_bf_checks: u64,
 
     #[cfg_attr(
         feature = "serde",
         serde(skip_deserializing, skip_serializing, default = "default_padding_173")
     )]
     #[derivative(Debug = "ignore")]
-    pub padding1: [u64; 173],
+    pub padding1: [u64; 172],
 }
 
 #[cfg(feature = "serde")]
-fn default_padding_173() -> [u64; 173] {
-    [0; 173]
+fn default_padding_173() -> [u64; 172] {
+    [0; 172]
 }
 
 #[cfg(feature = "serde")]
@@ -120,17 +126,18 @@ impl Default for LendingMarket {
             insolvency_risk_unhealthy_ltv_pct: CLOSE_TO_INSOLVENCY_RISKY_LTV,
             max_liquidatable_debt_market_value_at_once: MAX_LIQUIDATABLE_VALUE_AT_ONCE,
             global_allowed_borrow_value: GLOBAL_ALLOWED_BORROW_VALUE,
-            global_unhealthy_borrow_value: GLOBAL_UNHEALTHY_BORROW_VALUE,
             min_full_liquidation_value_threshold: LIQUIDATION_CLOSE_VALUE,
+            reserved0: [0; 8],
             reserved1: [0; 8],
             referral_fee_bps: 0,
             price_refresh_trigger_to_max_age_pct: 0,
             elevation_groups: [ElevationGroup::default(); 32],
-            min_value_skip_liquidation_ltv_bf_checks: 0,
+            min_value_skip_liquidation_ltv_checks: 0,
+            min_value_skip_liquidation_bf_checks: 0,
             elevation_group_padding: [0; 90],
             min_net_value_in_obligation_sf: MIN_NET_VALUE_IN_OBLIGATION.to_bits(),
             name: [0; 32],
-            padding1: [0; 173],
+            padding1: [0; 172],
         }
     }
 }

--- a/programs/klend/src/state/mod.rs
+++ b/programs/klend/src/state/mod.rs
@@ -200,7 +200,7 @@ pub enum UpdateLendingMarketMode {
     UpdateEmergencyMode = 1,
     UpdateLiquidationCloseFactor = 2,
     UpdateLiquidationMaxValue = 3,
-    UpdateGlobalUnhealthyBorrow = 4,
+    DeprecatedUpdateGlobalUnhealthyBorrow = 4,
     UpdateGlobalAllowedBorrow = 5,
     UpdateRiskCouncil = 6,
     UpdateMinFullLiquidationThreshold = 7,
@@ -212,9 +212,10 @@ pub enum UpdateLendingMarketMode {
     UpdateAutodeleverageEnabled = 13,
     UpdateBorrowingDisabled = 14,
     UpdateMinNetValueObligationPostAction = 15,
-    UpdateMinValueSkipPriorityLiqCheck = 16,
-    UpdatePaddingFields = 17,
-    UpdateName = 18,
+    UpdateMinValueLtvSkipPriorityLiqCheck = 16,
+    UpdateMinValueBfSkipPriorityLiqCheck = 17,
+    UpdatePaddingFields = 18,
+    UpdateName = 19,
 }
 
 #[cfg(feature = "serde")]

--- a/programs/klend/src/utils/consts.rs
+++ b/programs/klend/src/utils/consts.rs
@@ -46,8 +46,6 @@ pub const REFERRER_STATE_SIZE: usize = 64;
 pub const SHORT_URL_SIZE: usize = 68;
 pub const TOKEN_INFO_SIZE: usize = 384;
 
-pub const GLOBAL_UNHEALTHY_BORROW_VALUE: u64 = 50_000_000;
-
 pub const GLOBAL_ALLOWED_BORROW_VALUE: u64 = 45_000_000;
 
 pub const DEFAULT_BORROW_FACTOR_PCT: u64 = 100;


### PR DESCRIPTION
- Add flag to skip ltv priority
- Make referrer an account argument rather than parameter when initialising referrer token states
- Add constraint on disable usage as coll in request elevation group
- Add missing refresh obligation checks
- Remove global unhealthy borrow value