### PR TITLE
Prepare release 1.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kamino_lending"
-version = "1.11.0"
+version = "1.12.3"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/klend/Cargo.toml
+++ b/programs/klend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamino_lending"
-version = "1.11.0"
+version = "1.12.3"
 description = "Kamino lending Solana program"
 edition = "2021"
 license = "BUSL-1.1"

--- a/programs/klend/src/handlers/handler_update_lending_market.rs
+++ b/programs/klend/src/handlers/handler_update_lending_market.rs
@@ -162,6 +162,9 @@ pub fn process(
                 .validating(validations::check_bool)
                 .set(&value)?;
         }
+        UpdateLendingMarketMode::UpdateProposerAuthority => {
+            config_items::for_named_field!(&mut market.proposer_authority).set(&value)?;
+        }
     }
 
     Ok(())

--- a/programs/klend/src/lib.rs
+++ b/programs/klend/src/lib.rs
@@ -450,7 +450,7 @@ pub enum LendingError {
     InvalidAmount,
     #[msg("Input config value is invalid")]
     InvalidConfig,
-    #[msg("Input account must be a signer")]
+    #[msg("Signer is not allowed to perform this action")]
     InvalidSigner,
     #[msg("Invalid account input")]
     InvalidAccountInput,

--- a/programs/klend/src/state/lending_market.rs
+++ b/programs/klend/src/state/lending_market.rs
@@ -148,12 +148,16 @@ pub struct LendingMarket {
     #[derivative(Debug = "ignore")]
     pub padding2: [u8; 5],
 
+
+    #[cfg_attr(feature = "serde", serde(with = "serde_string", default))]
+    pub proposer_authority: Pubkey,
+
     #[cfg_attr(
         feature = "serde",
         serde(skip_deserializing, skip_serializing, default = "default_array")
     )]
     #[derivative(Debug = "ignore")]
-    pub padding1: [u64; 169],
+    pub padding1: [u64; 165],
 }
 
 impl Default for LendingMarket {
@@ -188,6 +192,7 @@ impl Default for LendingMarket {
             obligation_order_execution_enabled: 0,
             immutable: 0,
             obligation_order_creation_enabled: 0,
+            proposer_authority: Pubkey::default(),
             padding2: default_array(),
             padding1: default_array(),
         }

--- a/programs/klend/src/state/mod.rs
+++ b/programs/klend/src/state/mod.rs
@@ -141,6 +141,7 @@ pub enum UpdateConfigMode {
     UpdateAutodeleverageEnabled = 48,
     UpdateDeleveragingBonusIncreaseBpsPerDay = 49,
     UpdateProtocolOrderExecutionFee = 50,
+    UpdateProposerAuthorityLock = 51,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Clone, Debug)]
@@ -231,6 +232,7 @@ pub enum UpdateLendingMarketMode {
     UpdateObligationOrderExecutionEnabled = 22,
     UpdateImmutableFlag = 23,
     UpdateObligationOrderCreationEnabled = 24,
+    UpdateProposerAuthority = 25,
 }
 
 #[cfg(feature = "serde")]

--- a/programs/klend/src/state/reserve.rs
+++ b/programs/klend/src/state/reserve.rs
@@ -401,6 +401,21 @@ impl Reserve {
         let available_unclaimed: u64 = Fraction::from_bits(available_unclaimed_sf).to_floor();
         min(available_unclaimed, self.liquidity.available_amount)
     }
+
+
+
+
+
+    pub fn is_used(&self, min_initial_deposit_amount: u64) -> bool {
+        self.liquidity.available_amount > min_initial_deposit_amount
+            || self.liquidity.total_borrow() > Fraction::ZERO
+            || self.collateral.mint_total_supply > min_initial_deposit_amount
+    }
+
+
+    pub fn is_usage_blocked(&self) -> bool {
+        self.config.deposit_limit == 0 && self.config.borrow_limit == 0
+    }
 }
 
 
@@ -1010,7 +1025,7 @@ pub struct ReserveConfig {
 
     #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
     #[derivative(Debug = "ignore")]
-    pub reserved_2: [u8; 9],
+    pub reserved_1: [u8; 9],
 
     pub protocol_order_execution_fee_pct: u8,
 
@@ -1068,9 +1083,13 @@ pub struct ReserveConfig {
     #[cfg_attr(feature = "serde", serde(with = "serde_bool_u8"))]
     pub autodeleverage_enabled: u8,
 
-    #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
-    #[derivative(Debug = "ignore")]
-    pub reserved_1: [u8; 1],
+
+
+
+
+
+    #[cfg_attr(feature = "serde", serde(with = "serde_bool_u8"))]
+    pub proposer_authority_locked: u8,
 
 
 

--- a/programs/klend/src/utils/fraction.rs
+++ b/programs/klend/src/utils/fraction.rs
@@ -77,6 +77,11 @@ pub trait FractionExtra {
 
     fn mul_int_ratio(&self, numerator: impl Into<u128>, denominator: impl Into<u128>) -> Self;
     fn full_mul_int_ratio(&self, numerator: impl Into<U256>, denominator: impl Into<U256>) -> Self;
+    fn full_mul_int_ratio_ceil(
+        &self,
+        numerator: impl Into<U256>,
+        denominator: impl Into<U256>,
+    ) -> Self;
 
     fn div_ceil(&self, denominator: &Self) -> Self;
 
@@ -138,6 +143,22 @@ impl FractionExtra for Fraction {
         let denominator = denominator.into();
         let big_sf = U256::from(self.to_bits());
         let big_sf_res = big_sf * numerator / denominator;
+        let sf_res: u128 = big_sf_res
+            .try_into()
+            .expect("Denominator is not big enough, the result doesn't fit in a Fraction.");
+        Fraction::from_bits(sf_res)
+    }
+
+    #[inline]
+    fn full_mul_int_ratio_ceil(
+        &self,
+        numerator: impl Into<U256>,
+        denominator: impl Into<U256>,
+    ) -> Self {
+        let numerator = numerator.into();
+        let denominator = denominator.into();
+        let big_sf = U256::from(self.to_bits());
+        let big_sf_res = (big_sf * numerator + denominator - 1) / denominator;
         let sf_res: u128 = big_sf_res
             .try_into()
             .expect("Denominator is not big enough, the result doesn't fit in a Fraction.");


### PR DESCRIPTION
- Introduce the proposer authority (able to create non-active reserves). - Audited by Certora, Offside and OtterSec
- Transfer more fee parameters under the global config authority. - Audited by Offside
- Add util `full_mul_int_ratio_ceil` (not called in smart contract)
