### PR TITLE
Prepare release 1.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kamino_lending"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/libs/klend-interface/Cargo.lock
+++ b/libs/klend-interface/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "klend-interface"
-version = "0.2.0"
+version = "0.5.0"
 dependencies = [
  "borsh 0.10.4",
  "bytemuck",

--- a/libs/klend-interface/Cargo.toml
+++ b/libs/klend-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klend-interface"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.86.0"
 description = "Instruction builders for Kamino Lending (klend) — no anchor-lang dependency"

--- a/libs/klend-interface/src/errors.rs
+++ b/libs/klend-interface/src/errors.rs
@@ -264,7 +264,7 @@ define_lending_errors! {
     ObligationHasActiveBorrowOrders = 181 => "Obligation has active borrow orders",
     OnlyComputeBudgetCompanionIxsAllowed = 182 => "Only ComputeBudget instructions may accompany this instruction",
     MissingPermissioner = 183 => "Required permissioning account is missing",
-    ReserveRewardsDisabled = 184 => "Reserve rewards are disabled on this market (reserve_rewards_max_apr_pct is 0)",
+    ReserveRewardsDisabled = 184 => "Reserve rewards are disabled on this market (reserve_rewards_max_apr_bps is 0)",
 }
 
 impl std::error::Error for LendingError {}

--- a/libs/klend-interface/src/state/lending_market.rs
+++ b/libs/klend-interface/src/state/lending_market.rs
@@ -53,9 +53,9 @@ pub struct LendingMarket {
     pub obligation_borrow_rollover_configuration_enabled: u8,
     pub obligation_borrow_migration_to_fixed_execution_enabled: u8,
     pub withdraw_ticket_cancellation_enabled: u8,
-    /// Cap (in percent) on reserve rewards distribution APR
-    pub reserve_rewards_max_apr_pct: u8,
-    pub padding2: [u8; 2],
+    pub padding2: [u8; 1],
+    /// Cap (in basis points; `FULL_BPS = 10_000` = 100%) on reserve rewards distribution APR
+    pub reserve_rewards_max_apr_bps: u16,
     pub min_withdraw_queued_liquidity_value: u64,
     pub fixed_term_rollover_window_duration_seconds: u64,
     pub open_term_rollover_window_duration_seconds: u64,

--- a/programs/klend/Cargo.toml
+++ b/programs/klend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamino_lending"
-version = "1.21.0"
+version = "1.22.0"
 description = "Kamino lending Solana program"
 edition = "2021"
 license = "BUSL-1.1"

--- a/programs/klend/src/handlers/handler_cancel_withdraw_ticket.rs
+++ b/programs/klend/src/handlers/handler_cancel_withdraw_ticket.rs
@@ -47,7 +47,7 @@ pub fn process(
         clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
    

--- a/programs/klend/src/handlers/handler_deposit_and_withdraw.rs
+++ b/programs/klend/src/handlers/handler_deposit_and_withdraw.rs
@@ -63,7 +63,7 @@ pub fn process(
             &clock,
             None,
             lending_market.referral_fee_bps,
-            lending_market.reserve_rewards_max_apr_pct,
+            lending_market.reserve_rewards_max_apr_bps,
         )?;
         let timestamp = u64::try_from(clock.unix_timestamp).unwrap();
         lending_operations::refresh_reserve_limit_timestamps(&mut reserve, timestamp);
@@ -101,7 +101,7 @@ pub fn process(
             &clock,
             None,
             lending_market.referral_fee_bps,
-            lending_market.reserve_rewards_max_apr_pct,
+            lending_market.reserve_rewards_max_apr_bps,
         )?;
         let timestamp = u64::try_from(clock.unix_timestamp).unwrap();
         lending_operations::refresh_reserve_limit_timestamps(&mut reserve, timestamp);

--- a/programs/klend/src/handlers/handler_deposit_obligation_collateral.rs
+++ b/programs/klend/src/handlers/handler_deposit_obligation_collateral.rs
@@ -77,7 +77,7 @@ fn process_impl(
         &clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
     lending_operations::deposit_obligation_collateral(

--- a/programs/klend/src/handlers/handler_deposit_reserve_liquidity.rs
+++ b/programs/klend/src/handlers/handler_deposit_reserve_liquidity.rs
@@ -51,7 +51,7 @@ pub fn process(ctx: Context<DepositReserveLiquidity>, liquidity_amount: u64) -> 
         &clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
     let initial_reserve_token_balance = token_interface::accessor::amount(

--- a/programs/klend/src/handlers/handler_deposit_reserve_liquidity_and_obligation_collateral.rs
+++ b/programs/klend/src/handlers/handler_deposit_reserve_liquidity_and_obligation_collateral.rs
@@ -96,7 +96,7 @@ pub(super) fn process_impl(
         &clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
     let initial_reserve_token_balance =
@@ -113,7 +113,7 @@ pub(super) fn process_impl(
         &clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
     lending_operations::deposit_obligation_collateral(

--- a/programs/klend/src/handlers/handler_enqueue_to_withdraw.rs
+++ b/programs/klend/src/handlers/handler_enqueue_to_withdraw.rs
@@ -41,7 +41,7 @@ pub fn process(
         clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
     let initial_owner_queued_collateral_vault_balance =

--- a/programs/klend/src/handlers/handler_flash_borrow_reserve_liquidity.rs
+++ b/programs/klend/src/handlers/handler_flash_borrow_reserve_liquidity.rs
@@ -24,7 +24,7 @@ pub fn process(ctx: Context<FlashBorrowReserveLiquidity>, liquidity_amount: u64)
         &Clock::get()?,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
    

--- a/programs/klend/src/handlers/handler_redeem_reserve_collateral.rs
+++ b/programs/klend/src/handlers/handler_redeem_reserve_collateral.rs
@@ -44,7 +44,7 @@ pub fn process(ctx: Context<RedeemReserveCollateral>, collateral_amount: u64) ->
         &clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
    

--- a/programs/klend/src/handlers/handler_refresh_reserve.rs
+++ b/programs/klend/src/handlers/handler_refresh_reserve.rs
@@ -51,7 +51,7 @@ pub fn process(ctx: Context<RefreshReserve>) -> Result<()> {
         clock,
         price_res,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
     let timestamp = u64::try_from(clock.unix_timestamp).unwrap();
     lending_operations::refresh_reserve_limit_timestamps(reserve, timestamp);

--- a/programs/klend/src/handlers/handler_refresh_reserves_batch.rs
+++ b/programs/klend/src/handlers/handler_refresh_reserves_batch.rs
@@ -98,7 +98,7 @@ pub fn process(ctx: Context<RefreshReservesBatch>, skip_price_updates: bool) -> 
             clock,
             price_res,
             lending_market.referral_fee_bps,
-            lending_market.reserve_rewards_max_apr_pct,
+            lending_market.reserve_rewards_max_apr_bps,
         )?;
         let timestamp = u64::try_from(clock.unix_timestamp).unwrap();
         lending_operations::refresh_reserve_limit_timestamps(reserve, timestamp);

--- a/programs/klend/src/handlers/handler_repay_and_withdraw_redeem.rs
+++ b/programs/klend/src/handlers/handler_repay_and_withdraw_redeem.rs
@@ -107,7 +107,7 @@ fn process_impl(
                 &clock,
                 None,
                 lending_market.referral_fee_bps,
-                lending_market.reserve_rewards_max_apr_pct,
+                lending_market.reserve_rewards_max_apr_bps,
             )?;
         }
 
@@ -199,7 +199,7 @@ fn process_impl(
                 &clock,
                 None,
                 lending_market.referral_fee_bps,
-                lending_market.reserve_rewards_max_apr_pct,
+                lending_market.reserve_rewards_max_apr_bps,
             )?;
         }
 

--- a/programs/klend/src/handlers/handler_topup_reserve_rewards.rs
+++ b/programs/klend/src/handlers/handler_topup_reserve_rewards.rs
@@ -30,7 +30,7 @@ pub fn process(ctx: Context<TopupReserveRewards>, amount: u64) -> Result<()> {
         &clock,
         None,
         market.referral_fee_bps,
-        market.reserve_rewards_max_apr_pct,
+        market.reserve_rewards_max_apr_bps,
     )?;
 
     let initial_vault_balance = token_interface::accessor::amount(

--- a/programs/klend/src/handlers/handler_update_lending_market.rs
+++ b/programs/klend/src/handlers/handler_update_lending_market.rs
@@ -301,10 +301,13 @@ pub fn process(
                 .rendering(renderings::as_permissioned_ops_bitflags)
                 .set(&value)?;
         }
-        UpdateLendingMarketMode::UpdateReserveRewardsMaxAprPct => {
-            config_items::for_named_field!(&mut market.reserve_rewards_max_apr_pct)
-                .validating(validations::check_valid_pct)
+        UpdateLendingMarketMode::UpdateReserveRewardsMaxAprBps => {
+            config_items::for_named_field!(&mut market.reserve_rewards_max_apr_bps)
+                .validating(validations::check_valid_bps)
                 .set(&value)?;
+        }
+        UpdateLendingMarketMode::DeprecatedUpdateReserveRewardsMaxAprPct => {
+            panic!("Deprecated field")
         }
     }
 

--- a/programs/klend/src/handlers/handler_update_reserve_config.rs
+++ b/programs/klend/src/handlers/handler_update_reserve_config.rs
@@ -51,7 +51,7 @@ pub fn process(
         &clock,
         None,
         market.referral_fee_bps,
-        market.reserve_rewards_max_apr_pct,
+        market.reserve_rewards_max_apr_bps,
     )?;
 
     lending_operations::update_reserve_config(reserve, mode, value, &clock)?;

--- a/programs/klend/src/handlers/handler_withdraw_queued_liquidity.rs
+++ b/programs/klend/src/handlers/handler_withdraw_queued_liquidity.rs
@@ -105,7 +105,7 @@ pub fn process(ctx: Context<WithdrawQueuedLiquidity>) -> Result<bool> {
         &clock,
         None,
         lending_market.referral_fee_bps,
-        lending_market.reserve_rewards_max_apr_pct,
+        lending_market.reserve_rewards_max_apr_bps,
     )?;
 
    

--- a/programs/klend/src/lending_market/lending_operations.rs
+++ b/programs/klend/src/lending_market/lending_operations.rs
@@ -44,7 +44,7 @@ pub fn refresh_reserve(
     clock: &Clock,
     price: Option<GetPriceResult>,
     referral_fee_bps: u16,
-    reserve_rewards_max_apr_pct: u8,
+    reserve_rewards_max_apr_bps: u16,
 ) -> Result<()> {
     let slot = clock.slot;
 
@@ -52,7 +52,7 @@ pub fn refresh_reserve(
     reserve.accrue_interest(slot, referral_fee_bps)?;
 
    
-    reserve.distribute_rewards(slot, reserve_rewards_max_apr_pct)?;
+    reserve.distribute_rewards(slot, reserve_rewards_max_apr_bps)?;
 
    
     let price_status = if reserve.config.is_emergency_mode() {
@@ -2114,7 +2114,7 @@ where
             clock,
             None,
             lending_market.referral_fee_bps,
-            lending_market.reserve_rewards_max_apr_pct,
+            lending_market.reserve_rewards_max_apr_bps,
         )?;
         let redeem_collateral_options = RedeemCollateralOptions::resolve(liquidation_reason);
         let max_redeemable_collateral = if redeem_collateral_options.use_withdraw_queue {
@@ -4451,7 +4451,7 @@ pub mod utils {
         if config.rewards_amount_per_slot > 0 && !market.is_reserve_rewards_enabled() {
             msg!(
                 "WARNING: rewards_amount_per_slot={} is set but the market has reserve rewards \
-                 disabled (reserve_rewards_max_apr_pct == 0); RPS will be ignored on refresh \
+                 disabled (reserve_rewards_max_apr_bps == 0); RPS will be ignored on refresh \
                  until rewards are enabled at the market level",
                 config.rewards_amount_per_slot,
             );

--- a/programs/klend/src/lib.rs
+++ b/programs/klend/src/lib.rs
@@ -936,7 +936,7 @@ pub enum LendingError {
     OnlyComputeBudgetCompanionIxsAllowed,
     #[msg("Required permissioning account is missing")]
     MissingPermissioner,
-    #[msg("Reserve rewards are disabled on this market (reserve_rewards_max_apr_pct is 0)")]
+    #[msg("Reserve rewards are disabled on this market (reserve_rewards_max_apr_bps is 0)")]
     ReserveRewardsDisabled,
 }
 

--- a/programs/klend/src/state/lending_market.rs
+++ b/programs/klend/src/state/lending_market.rs
@@ -216,18 +216,18 @@ pub struct LendingMarket {
     #[cfg_attr(feature = "serde", serde(with = "serde_bool_u8"))]
     pub withdraw_ticket_cancellation_enabled: u8,
 
-
-
-
-
-    pub reserve_rewards_max_apr_pct: u8,
-
     #[cfg_attr(
         feature = "serde",
         serde(skip_deserializing, skip_serializing, default = "default_array")
     )]
     #[derivative(Debug = "ignore")]
-    pub padding2: [u8; 2],
+    pub padding2: [u8; 1],
+
+
+
+
+
+    pub reserve_rewards_max_apr_bps: u16,
 
 
 
@@ -349,8 +349,8 @@ impl Default for LendingMarket {
             min_partial_rollover_value: 0,
             permissioning_authority: Pubkey::default(),
             permissioned_ops: 0,
-            reserve_rewards_max_apr_pct: 0,
             padding2: default_array(),
+            reserve_rewards_max_apr_bps: 0,
             padding1: default_array(),
         }
     }
@@ -536,7 +536,7 @@ impl LendingMarket {
 
 
     pub fn is_reserve_rewards_enabled(&self) -> bool {
-        self.reserve_rewards_max_apr_pct > 0
+        self.reserve_rewards_max_apr_bps > 0
     }
 }
 

--- a/programs/klend/src/state/mod.rs
+++ b/programs/klend/src/state/mod.rs
@@ -262,7 +262,8 @@ pub enum UpdateLendingMarketMode {
     UpdateWithdrawTicketCancellationEnabled = 41,
     UpdatePermissioningAuthority = 42,
     UpdatePermissionedOps = 43,
-    UpdateReserveRewardsMaxAprPct = 44,
+    DeprecatedUpdateReserveRewardsMaxAprPct = 44,
+    UpdateReserveRewardsMaxAprBps = 45,
 }
 
 #[cfg(feature = "serde")]
@@ -296,6 +297,7 @@ pub mod serde_iter {
                 *self,
                 UpdateLendingMarketMode::DeprecatedUpdateMultiplierPoints
                     | UpdateLendingMarketMode::DeprecatedUpdateGlobalUnhealthyBorrow
+                    | UpdateLendingMarketMode::DeprecatedUpdateReserveRewardsMaxAprPct
             )
         }
 

--- a/programs/klend/src/state/reserve.rs
+++ b/programs/klend/src/state/reserve.rs
@@ -25,7 +25,7 @@ use crate::{
     state::{DepositLiquidityResult, LastUpdate, TokenInfo},
     utils::{
         accounts::default_array, borrow_rate_curve::BorrowRateCurve, ten_pow, BigFraction,
-        Fraction, FRACTION_ONE_SCALED, INITIAL_COLLATERAL_RATE, PROGRAM_VERSION,
+        Fraction, FRACTION_ONE_SCALED, FULL_BPS, INITIAL_COLLATERAL_RATE, PROGRAM_VERSION,
         RESERVE_CONFIG_SIZE, RESERVE_SIZE, SLOTS_PER_YEAR, U256,
     },
     BorrowSize, CalculateBorrowResult, CalculateRepayResult, LendingError, LendingResult,
@@ -573,10 +573,10 @@ impl Reserve {
 
 
 
-    pub fn distribute_rewards(&mut self, current_slot: Slot, max_apr_pct: u8) -> Result<u64> {
+    pub fn distribute_rewards(&mut self, current_slot: Slot, max_apr_bps: u16) -> Result<u64> {
         let slots_elapsed = self.last_update.slots_elapsed(current_slot)?;
         if slots_elapsed == 0
-            || max_apr_pct == 0
+            || max_apr_bps == 0
             || self.config.rewards_amount_per_slot == 0
             || self.liquidity.rewards_amount_available == 0
             || self.collateral.mint_total_supply == 0
@@ -596,9 +596,9 @@ impl Reserve {
        
         let total_supply_u128: u128 = self.liquidity.total_supply().to_floor();
         let apr_cap_numerator = total_supply_u128
-            .saturating_mul(u128::from(max_apr_pct))
+            .saturating_mul(u128::from(max_apr_bps))
             .saturating_mul(u128::from(slots_elapsed));
-        let apr_cap_denominator = 100u128 * u128::from(SLOTS_PER_YEAR);
+        let apr_cap_denominator = u128::from(FULL_BPS) * u128::from(SLOTS_PER_YEAR);
         let apr_cap_u128 = apr_cap_numerator / apr_cap_denominator;
 
         let to_distribute_u128 = raw_distribution


### PR DESCRIPTION
* Reserve rewards max APR field renamed to use basis points (`reserve_rewards_max_apr_bps`)