### PR TITLE
Add missing UpdateObligationConfigMode::FixedTermRolloverWindowDurationDays

### DIFF
--- a/libs/klend-interface/src/types.rs
+++ b/libs/klend-interface/src/types.rs
@@ -72,4 +72,32 @@ pub enum UpdateObligationConfigMode {
     FixedTermRolloverMinDebtTermSeconds = 2,
     FixedTermRolloverOpenTermAllowed = 3,
     MigrationToFixedEnabled = 4,
+    FixedTermRolloverWindowDurationDays = 5,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Borsh encodes an enum by its declaration index, so a variant inserted out of
+    /// order (or omitted) silently shifts the wire value of everything after it. The
+    /// klend program discriminants these must match live in `UpdateObligationConfigMode`
+    /// in `state/obligation.rs`.
+    #[test]
+    fn update_obligation_config_mode_discriminants() {
+        use UpdateObligationConfigMode::*;
+        let expected = [
+            (FixedTermRolloverEnabled, 0u8),
+            (FixedTermRolloverMaxBorrowRateBps, 1),
+            (FixedTermRolloverMinDebtTermSeconds, 2),
+            (FixedTermRolloverOpenTermAllowed, 3),
+            (MigrationToFixedEnabled, 4),
+            (FixedTermRolloverWindowDurationDays, 5),
+        ];
+        for (mode, discriminant) in expected {
+            let mut encoded = Vec::new();
+            mode.serialize(&mut encoded).unwrap();
+            assert_eq!(encoded, vec![discriminant], "wrong encoding for {mode:?}");
+        }
+    }
 }

--- a/libs/klend-interface/tests/integration/mod.rs
+++ b/libs/klend-interface/tests/integration/mod.rs
@@ -10,4 +10,5 @@ mod test_init;
 mod test_multi_reserve;
 mod test_obligation_context;
 mod test_refresh_batch;
+mod test_update_obligation_config;
 mod test_withdraw;

--- a/libs/klend-interface/tests/integration/test_update_obligation_config.rs
+++ b/libs/klend-interface/tests/integration/test_update_obligation_config.rs
@@ -1,0 +1,91 @@
+use klend_interface::{state::Obligation, types::UpdateObligationConfigMode};
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction};
+
+use super::setup::{self, build_obligation_info, build_reserve_info};
+
+fn send(env: &mut setup::TestEnv, ixs: &[solana_sdk::instruction::Instruction], user: &Keypair) {
+    let tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&user.pubkey()),
+        &[user],
+        env.svm.latest_blockhash(),
+    );
+    env.svm.send_transaction(tx).unwrap();
+}
+
+fn rollover_window_days(env: &setup::TestEnv, obligation: &Pubkey) -> u8 {
+    let account = env.svm.get_account(obligation).unwrap();
+    let obligation =
+        klend_interface::state::from_account_data::<Obligation>(&account.data).unwrap();
+    obligation.borrows[0]
+        .fixed_term_borrow_rollover_config
+        .fixed_term_rollover_window_duration_days
+}
+
+/// Drives `UpdateObligationConfigMode::FixedTermRolloverWindowDurationDays` (borsh
+/// discriminant 5) through the on-chain program and reads the result back, confirming the
+/// program decodes the variant this crate encodes and applies it to the intended field.
+#[test]
+fn test_update_obligation_config_sets_rollover_window_duration_days() {
+    let mut env = setup::setup_full_env();
+    let (user, obligation) = setup::create_user_and_obligation(&mut env);
+    let reserve_info = build_reserve_info(&env);
+
+    let deposit_amount = 10_000_000u64;
+    let user_ta =
+        setup::create_token_account(&mut env.svm, &user, &env.liquidity_mint, &user.pubkey());
+    setup::mint_to(
+        &mut env.svm,
+        &env.admin,
+        &env.liquidity_mint,
+        &user_ta,
+        deposit_amount,
+    );
+    let ixs = klend_interface::helpers::deposit_to_obligation(
+        user.pubkey(),
+        &reserve_info,
+        &build_obligation_info(&obligation, &env.reserve.pubkey(), false, false),
+        &[reserve_info.clone()],
+        user_ta,
+        deposit_amount,
+        None,
+    );
+    send(&mut env, &ixs, &user);
+    setup::advance_clock_by_slots(&mut env.svm, 1);
+
+    // The rollover config lives on a borrow position, so the obligation needs one.
+    let ixs = klend_interface::helpers::borrow(
+        user.pubkey(),
+        &reserve_info,
+        &build_obligation_info(&obligation, &env.reserve.pubkey(), true, false),
+        &[reserve_info.clone()],
+        user_ta,
+        100_000u64,
+        None,
+    );
+    send(&mut env, &ixs, &user);
+
+    assert_eq!(
+        rollover_window_days(&env, &obligation),
+        0,
+        "field should start unset"
+    );
+
+    const WINDOW_DAYS: u8 = 7;
+    let ix = klend_interface::helpers::update_obligation_config(
+        user.pubkey(),
+        obligation,
+        env.lending_market.pubkey(),
+        Some(env.reserve.pubkey()),
+        None,
+        UpdateObligationConfigMode::FixedTermRolloverWindowDurationDays,
+        vec![WINDOW_DAYS],
+    );
+    send(&mut env, &[ix], &user);
+
+    assert_eq!(
+        rollover_window_days(&env, &obligation),
+        WINDOW_DAYS,
+        "program should have applied the new mode to the borrow's rollover config"
+    );
+}


### PR DESCRIPTION
UpdateObligationConfigMode in the klend program has six variants, but klend-interface mirrors only five — FixedTermRolloverWindowDurationDays = 5 is missing.

It was added to the program in release 1.24.0 (#81). That commit touched libs/klend-interface/src/types.rs but didn't add the variant. The backing state field was mirrored correctly at the time — FixedTermBorrowRolloverConfig::fixed_term_rollover_window_duration_days is present in the interface — so only the enum used to set it was missed.

Because instructions::obligation::update_obligation_config takes the mode by value, callers of this crate currently cannot build that instruction at all.

Changes

- Add the missing variant to UpdateObligationConfigMode.
- Add a unit test pinning the borsh encoding of all six variants. Borsh serializes an enum by declaration index, so a variant added out of order silently shifts the wire value of everything after it — that's the failure mode that would let this drift recur unnoticed. Verified the test catches it by reordering two variants and watching it fail.
- Add an integration test that sends update_obligation_config with the new mode through the program on litesvm and reads the obligation back, confirming the program applies it to the borrow's rollover config. This exercises the program's decoding, not just this crate's encoding.

Testing

- cargo test --lib — 12 passed
- cargo test --test litesvm_integration — 37 passed
- cargo clippy --all-targets -- -D warnings — clean
- cargo fmt --check — clean

Some evidence for the change.

The gap — the program declares six modes, the interface mirrored five.

<img width="1355" height="1053" alt="Screenshot 2026-08-23 at 2 00 00 PM" src="https://github.com/user-attachments/assets/2c796e76-aec2-4cea-8475-a08599844f2c" />

After — the interface now matches.

<img width="1710" height="1112" alt="Screenshot 2026-08-23 at 1 52 59 PM" src="https://github.com/user-attachments/assets/ab36a5c7-0fea-4683-b2b0-a55aecacbee4" />

Why it matters — before the fix a caller can't construct the variant at all. This is the integration test from this PR failing to compile against the old enum.

<img width="1354" height="328" alt="Screenshot 2026-08-23 at 2 00 00 PM" src="https://github.com/user-attachments/assets/78a49839-2304-4e74-89e4-a059f3709551" />

Tests — 12 unit, 37 integration, clippy and fmt clean.

<img width="1351" height="1040" alt="Screenshot 2026-08-23 at 2 03 35 PM" src="https://github.com/user-attachments/assets/aad2001c-8776-4259-ad00-fd28a1b0ce1e" />